### PR TITLE
fix go print example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ import "fmt"
 
 func main() {
 	fmt.Println("hello world")
-	fmt.Println("hello %s", "world")
-	fmt.Println("hello %d %s", 5, "worlds")
+	fmt.Printf("hello %s\n", "world")
+	fmt.Printf("hello %d %s\n", 5, "worlds")
 }
 ```
 


### PR DESCRIPTION
The code snippet in the go file is fine, but the code in the readme was out of date.