### PR TITLE
refactor(big_numbers): use native bigint for node js

### DIFF
--- a/README.md
+++ b/README.md
@@ -2485,32 +2485,50 @@ Examples of creating big number types from and to uint, string, hex, and buffers
 #### Node.js
 
 ```node
-const BN = require('bn.js')
-
-let bn = new BN(75)
+let bn = 75n;
 console.log(bn.toString(10))
 
-bn = new BN('75')
+bn = BigInt('75')
 console.log(bn.toString(10))
 
-bn = new BN(0x4b, 'hex')
+bn = BigInt(0x4b)
 console.log(bn.toString(10))
 
-bn = new BN('4b', 'hex')
+bn = BigInt('0x' + '4b')
 console.log(bn.toString(10))
 
-bn = new BN(Buffer.from('4b', 'hex'))
+bn = BigInt('0x' + Buffer.from('4b', 'hex').toString('hex'))
 console.log(bn.toString(10))
-console.log(bn.toNumber(10))
-console.log(bn.toString('hex'))
-console.log(bn.toBuffer())
+console.log(Number(bn))
+console.log(bn.toString(16))
+console.log(Buffer.from(bn.toString(16), 'hex'))
 
-let bn2 = new BN(5)
-let isEqual = bn.cmp(bn2) == 0
+/**
+ * Compare numbers and return -1 (a < b), 0 (a == b), or 1 (a > b)
+ *
+ * @param {BigInt} a 
+ * @param {BigInt} b
+ * 
+ * @returns number
+ */
+function cmp(a, b) {
+    if (a < b) {
+        return -1;
+    }
+
+    if (a > b) {
+        return 1;
+    }
+
+    return 0;
+}
+
+let bn2 = BigInt(5)
+let isEqual = cmp(bn, bn2) == 0
 console.log(isEqual)
 
-bn2 = new BN('4b', 'hex')
-isEqual = bn.cmp(bn2) == 0
+bn2 = BigInt('0x' + '4b')
+isEqual = cmp(bn, bn2) == 0
 console.log(isEqual)
 ```
 

--- a/README.md
+++ b/README.md
@@ -2512,15 +2512,15 @@ console.log(Buffer.from(bn.toString(16), 'hex'))
  * @returns number
  */
 function cmp(a, b) {
-    if (a < b) {
-        return -1;
-    }
+	if (a < b) {
+		return -1;
+	}
 
-    if (a > b) {
-        return 1;
-    }
+	if (a > b) {
+		return 1;
+	}
 
-    return 0;
+	return 0;
 }
 
 let bn2 = BigInt(5)

--- a/examples/big_numbers.js
+++ b/examples/big_numbers.js
@@ -25,15 +25,15 @@ console.log(Buffer.from(bn.toString(16), 'hex'))
  * @returns number
  */
 function cmp(a, b) {
-    if (a < b) {
-        return -1;
-    }
+	if (a < b) {
+		return -1;
+	}
 
-    if (a > b) {
-        return 1;
-    }
+	if (a > b) {
+		return 1;
+	}
 
-    return 0;
+	return 0;
 }
 
 let bn2 = BigInt(5)

--- a/examples/big_numbers.js
+++ b/examples/big_numbers.js
@@ -1,27 +1,45 @@
-const BN = require('bn.js')
-
-let bn = new BN(75)
+let bn = 75n;
 console.log(bn.toString(10))
 
-bn = new BN('75')
+bn = BigInt('75')
 console.log(bn.toString(10))
 
-bn = new BN(0x4b, 'hex')
+bn = BigInt(0x4b)
 console.log(bn.toString(10))
 
-bn = new BN('4b', 'hex')
+bn = BigInt('0x' + '4b')
 console.log(bn.toString(10))
 
-bn = new BN(Buffer.from('4b', 'hex'))
+bn = BigInt('0x' + Buffer.from('4b', 'hex').toString('hex'))
 console.log(bn.toString(10))
-console.log(bn.toNumber(10))
-console.log(bn.toString('hex'))
-console.log(bn.toBuffer())
+console.log(Number(bn))
+console.log(bn.toString(16))
+console.log(Buffer.from(bn.toString(16), 'hex'))
 
-let bn2 = new BN(5)
-let isEqual = bn.cmp(bn2) == 0
+/**
+ * Compare numbers and return -1 (a < b), 0 (a == b), or 1 (a > b)
+ *
+ * @param {BigInt} a 
+ * @param {BigInt} b
+ * 
+ * @returns number
+ */
+function cmp(a, b) {
+    if (a < b) {
+        return -1;
+    }
+
+    if (a > b) {
+        return 1;
+    }
+
+    return 0;
+}
+
+let bn2 = BigInt(5)
+let isEqual = cmp(bn, bn2) == 0
 console.log(isEqual)
 
-bn2 = new BN('4b', 'hex')
-isEqual = bn.cmp(bn2) == 0
+bn2 = BigInt('0x' + '4b')
+isEqual = cmp(bn, bn2) == 0
 console.log(isEqual)


### PR DESCRIPTION
The [BN.JS](https://github.com/indutny/bn.js) is an external dependency for node.js, I think we should use native [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) wherever needed.